### PR TITLE
Make `raw_input` available on Python 3

### DIFF
--- a/rpl
+++ b/rpl
@@ -5,6 +5,12 @@ try: import readline
 except ImportError: pass
 from stat import *
 
+try:
+    raw_input
+except NameError:
+    # Python 3.x
+    raw_input = input
+
 def show_license(*eat):
     print ("""rpl - replace strings in files
 Copyright (C) 2004-2005 Goran Weinholt <weinholt@debian.org>


### PR DESCRIPTION
If the replacement string is empty, a prompt should be shown that asks the user to confirm the deletion of text:

```sh
$ python3 rpl 'foo' '' .
Really DELETE all occurences of def (case sensitive)? (Y/[N])
```

On Python 3, this fails:
```pytb
Traceback (most recent call last):
  File "rpl", line 314, in <module>
    main()
  File "rpl", line 172, in main
    line = raw_input()
NameError: name 'raw_input' is not defined
```

Python 2.x's `raw_input` is available on Python 3.x as `input` (it had been renamed).
To fix the issue, I have attached a patch that provides `input` as `raw_input`, too.
