### PR TITLE
Fix "Exception when locale is undefined or C" (Debian bug #852813)

### DIFF
--- a/rpl
+++ b/rpl
@@ -70,6 +70,10 @@ def unescape(s):
 
 def blockrepl(instream, outstream, regex, before, after, blocksize=None):
     encoding = locale.getdefaultlocale()[1]
+    if encoding is None:
+        sys.stderr.write("Could not determine default locale.")
+        sys.exit(os.EX_CONFIG)
+
     patlen = len(before)
     sum = 0
     if not blocksize: blocksize = 2*patlen


### PR DESCRIPTION
If `LANG=C` is set on Python 3, the encoding would be `None`. See [Debian bug #852813](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852813) for details.

To at least get rid of the exception and traceback, I have attached a patch that prints an error message and exits.

A more elaborate fix might be to provide a fallback encoding (maybe ASCII?). Then again, I'm not sure why the encoding is dependent of the locale at all.
Maybe it should be a robust default (UTF-8?) that can optionally be overridden?